### PR TITLE
Add pedestrian label, remove error log

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -438,9 +438,10 @@ double calcLongitudinalOffsetToSegment(
     if (throw_exception) {
       throw std::runtime_error(error_message);
     }
-    log_error(
+    /*log_error(
       error_message +
       " Return NaN since no_throw option is enabled. The maintainer must check the code.");
+    */ //commented out since it was filling up the logs with unnecessary error messages YH
     return std::nan("");
   }
 

--- a/perception/euclidean_cluster/lib/utils.cpp
+++ b/perception/euclidean_cluster/lib/utils.cpp
@@ -56,7 +56,8 @@ void convertPointCloudClusters2Msg(
     feature_object.object.kinematics.pose_with_covariance.pose.position =
       getCentroid(ros_pointcloud);
     autoware_auto_perception_msgs::msg::ObjectClassification classification;
-    classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+    //classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+    classification.label = autoware_auto_perception_msgs::msg::ObjectClassification::PEDESTRIAN; //change label to pedestrian YH
     classification.probability = 1.0f;
     feature_object.object.classification.emplace_back(classification);
     msg.feature_objects.push_back(feature_object);


### PR DESCRIPTION
Changed the default "unknown" label to "pedestrian". Removed "Longitudinal offset calculation is not supported for the same points" message since it was unnecessary and was clogging the logs.
**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
